### PR TITLE
Fixed remaining bugs of the iOS purchase manager and added some logging.

### DIFF
--- a/gdx-pay-tests/src/com/badlogic/gdx/pay/tests/PayTest.java
+++ b/gdx-pay-tests/src/com/badlogic/gdx/pay/tests/PayTest.java
@@ -60,9 +60,11 @@ public class PayTest extends ApplicationAdapter {
         if (PurchaseSystem.hasManager()) {
             // build our purchase configuration: all your products and types need to be listed here
             final String IAP_TEST_CONSUMEABLE = "com.badlogic.gdx.tests.pay.consumeable";
+            final String IAP_TEST_NONCONSUMEABLE = "com.badlogic.gdx.tests.pay.nonconsumeable";
             PurchaseManagerConfig config = new PurchaseManagerConfig();
             config.addOffer(new Offer().setType(OfferType.CONSUMABLE).setIdentifier(IAP_TEST_CONSUMEABLE)
                 .putIdentifierForStore(PurchaseManagerConfig.STORE_NAME_ANDROID_GOOGLE, "android.test.purchased"));
+            config.addOffer(new Offer().setType(OfferType.ENTITLEMENT).setIdentifier(IAP_TEST_NONCONSUMEABLE));
 
             // install the observer
             PurchaseSystem.install(new PurchaseObserver() {
@@ -74,7 +76,7 @@ public class PayTest extends ApplicationAdapter {
                         message("   . " + transactions[i].getIdentifier() + "\n");
                     }
 
-                    // restore purchases!
+                    // make a purchase
                     message(" - purchasing: " + IAP_TEST_CONSUMEABLE + ".\n");
                     PurchaseSystem.purchase(IAP_TEST_CONSUMEABLE);
                 }
@@ -128,8 +130,17 @@ public class PayTest extends ApplicationAdapter {
 
                 @Override
                 public void handlePurchaseCanceled () {
-                    // TODO Auto-generated method stub
+                    message(" - purchase cancelled.\n");
 
+                    // dispose the purchase system
+                    Gdx.app.postRunnable(new Runnable() {
+                        @Override
+                        public void run () {
+                            message(" - disposing the purchase manager.\n");
+                            PurchaseSystem.dispose();
+                            message("Testing InApp System: COMPLETED\n");
+                        }
+                    });
                 }
             }, config);
 


### PR DESCRIPTION
This PR fixes the remaining bugs. The iOS purchase manager has been thoroughly tested now and did work for me everytime.

To test the iOS manager just:
1. create a new app in iTunes Connect using your wild-card (*) bundle identifier and add the bundle id from the test app as a suffix.
2. Create a new in-app-purchase using a distinctive product identifier. Use something distinctive you won't use again (you won't be able to use that id again even if you delete the in-app-purchase!!!).
3. Update the gdx-pay sample and change the product offer id to the product identifier you used in step 2.
4. (optional) Create a test user for your country. Use a distinctive (non-existing) email address (you won't be able to use that email address again with Apple products even after deleting the test user!!!).
5. Log out from your apple account on your iDevice.
6. Launch the gdx-pay ios test app. When asked, login with the credentials you created in step 4.
