### PR TITLE
Updated function naming to use RoboVM 1.0 calls for createFromProduct

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
-        classpath 'org.robovm:robovm-gradle-plugin:1.0.0-alpha-04'
+        classpath 'org.robovm:robovm-gradle-plugin:1.0.0'
     }
 }
 
@@ -144,8 +144,8 @@ project(":gdx-pay-iosrobovm-apple") {
     
     dependencies {
         compile project(':gdx-pay')
-        compile 'org.robovm:robovm-rt:1.0.0-SNAPSHOT'
-        compile 'org.robovm:robovm-cocoatouch:1.0.0-SNAPSHOT'
+        compile 'org.robovm:robovm-rt:1.0.0'
+        compile 'org.robovm:robovm-cocoatouch:1.0.0'
     }
 }
 
@@ -222,10 +222,10 @@ project(":gdx-pay-tests-iosrobovm") {
            
         compile project(':gdx-pay-iosrobovm-apple')
 
-        compile "org.robovm:robovm-rt:1.0.0-SNAPSHOT"
-        compile "org.robovm:robovm-cocoatouch:1.0.0-SNAPSHOT"
-        compile "com.badlogicgames.gdx:gdx-backend-robovm:1.4.1"
-        natives "com.badlogicgames.gdx:gdx-platform:1.4.1:natives-ios"
+        compile "org.robovm:robovm-rt:1.0.0"
+        compile "org.robovm:robovm-cocoatouch:1.0.0"
+        compile "com.badlogicgames.gdx:gdx-backend-robovm:1.5.5"
+        natives "com.badlogicgames.gdx:gdx-platform:1.5.5:natives-ios"
     }
 }
 

--- a/gdx-pay-android-openiab/src/com/badlogic/gdx/pay/android/openiab/PurchaseManagerAndroidOpenIAB.java
+++ b/gdx-pay-android-openiab/src/com/badlogic/gdx/pay/android/openiab/PurchaseManagerAndroidOpenIAB.java
@@ -391,7 +391,11 @@ public class PurchaseManagerAndroidOpenIAB implements PurchaseManager {
 
 	@Override
     public Information getInformation(String identifier) {
-	    // not implemented yet for this purchase manager
+        SkuDetails details = inventory.getSkuDetails(identifier);
+        if(details != null) {
+            Information i = new Information(details.getTitle(), details.getDescription(), details.getPrice());
+            return i;
+        }
         return Information.UNAVAILABLE;
     }
 

--- a/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -27,6 +27,9 @@ import org.robovm.apple.foundation.NSBundle;
 import org.robovm.apple.foundation.NSData;
 import org.robovm.apple.foundation.NSDataBase64EncodingOptions;
 import org.robovm.apple.foundation.NSError;
+import org.robovm.apple.foundation.NSNumberFormatter;
+import org.robovm.apple.foundation.NSNumberFormatterBehavior;
+import org.robovm.apple.foundation.NSNumberFormatterStyle;
 import org.robovm.apple.foundation.NSURL;
 import org.robovm.apple.storekit.SKErrorCode;
 import org.robovm.apple.storekit.SKPayment;
@@ -78,6 +81,8 @@ public class PurchaseManageriOSApple implements PurchaseManager {
     private static final boolean LOGDEBUG = true;
     private static final int LOGTYPELOG = 0;
     private static final int LOGTYPEERROR = 1;
+
+    private static NSNumberFormatter numberFormatter;
 
     private PurchaseObserver observer;
     private PurchaseManagerConfig config;
@@ -416,10 +421,20 @@ public class PurchaseManageriOSApple implements PurchaseManager {
         }
     }
 
-
     @Override
     public Information getInformation(String identifier) {
-        // not implemented yet for this purchase manager
+        for(SKProduct p : products) {
+            if(p.getProductIdentifier().equals(identifier)) {
+                if(numberFormatter == null) {
+                    numberFormatter = new NSNumberFormatter();
+                    numberFormatter.setFormatterBehavior(NSNumberFormatterBehavior._10_4);
+                    numberFormatter.setNumberStyle(NSNumberFormatterStyle.Currency);
+                }
+                numberFormatter.setLocale(p.getPriceLocale());
+                Information i = new Information(p.getLocalizedTitle(), p.getLocalizedDescription(), numberFormatter.format(p.getPrice()));
+                return i;
+            }
+        }
         return Information.UNAVAILABLE;
     }
     

--- a/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -160,7 +160,7 @@ public class PurchaseManageriOSApple implements PurchaseManager {
         else {
             // Create a SKPayment from the product and start purchase flow
             log(LOGTYPELOG, "Purchasing product " + identifier + " ...");
-            SKPayment payment = SKPayment.createFromProduct(product);
+            SKPayment payment = SKPayment.create(product);
             SKPaymentQueue.getDefaultQueue().addPayment(payment);
         }
     }
@@ -226,7 +226,7 @@ public class PurchaseManageriOSApple implements PurchaseManager {
             // Create a SKPayment from the product and start purchase flow
             SKProduct product = products.get(0);
             log(LOGTYPELOG, "Product info received/purchasing product " + product.getProductIdentifier() + " ...");
-            SKPayment payment = SKPayment.createFromProduct(product);
+            SKPayment payment = SKPayment.create(product);
             SKPaymentQueue.getDefaultQueue().addPayment(payment);
           }
           else {


### PR DESCRIPTION
A word of warning: from this commit on, you have to have RoboVM 1.0.0.
This change will break compatibility with older versions of RoboVM.

The latest LibGDX setup app installs with LibGDX 1.5.5 and RoboVM 1.0.0, so what would be best is to add some kind of warning in a upgrade guide or something like that.

I can do backwards compatibility if the need arises (and if I have time to do so)