### PR TITLE
Update to robovm 1.8 for ios9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
-        classpath 'org.robovm:robovm-gradle-plugin:1.0.0'
+        classpath 'org.robovm:robovm-gradle-plugin:1.8.0'
     }
 }
 
@@ -162,8 +162,8 @@ project(":gdx-pay-iosrobovm-apple") {
     
     dependencies {
         compile project(':gdx-pay-client')
-        compile 'org.robovm:robovm-rt:1.0.0'
-        compile 'org.robovm:robovm-cocoatouch:1.0.0'
+        compile 'org.robovm:robovm-rt:1.8.0'
+        compile 'org.robovm:robovm-cocoatouch:1.8.0'
     }
 }
 

--- a/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -166,7 +166,7 @@ public class PurchaseManageriOSApple implements PurchaseManager {
         else {
             // Create a SKPayment from the product and start purchase flow
             log(LOGTYPELOG, "Purchasing product " + identifier + " ...");
-            SKPayment payment = SKPayment.create(product);
+            SKPayment payment = new SKPayment(product);
             SKPaymentQueue.getDefaultQueue().addPayment(payment);
         }
     }
@@ -237,7 +237,7 @@ public class PurchaseManageriOSApple implements PurchaseManager {
             // Create a SKPayment from the product and start purchase flow
             SKProduct product = products.get(0);
             log(LOGTYPELOG, "Product info received/purchasing product " + product.getProductIdentifier() + " ...");
-            SKPayment payment = SKPayment.create(product);
+            SKPayment payment = new SKPayment(product);
             SKPaymentQueue.getDefaultQueue().addPayment(payment);
           }
           else {


### PR DESCRIPTION
Since gdx-pay currently doesn't compile with robovm 1.8, it's probably best to do a new release as well.