### PR TITLE
Ios fixes

### DIFF
--- a/gdx-pay-iosrobovm-apple/build.gradle
+++ b/gdx-pay-iosrobovm-apple/build.gradle
@@ -8,5 +8,9 @@ sourceSets {
         java {
             srcDir 'src'
         }
+
+        resources {
+            srcDir 'resources'
+        }
     }
 }

--- a/gdx-pay-iosrobovm-apple/resources/META-INF/robovm/ios/robovm.xml
+++ b/gdx-pay-iosrobovm-apple/resources/META-INF/robovm/ios/robovm.xml
@@ -1,0 +1,5 @@
+<config>
+    <forceLinkClasses>
+        <pattern>com.badlogic.gdx.pay.ios.apple.PurchaseManageriOSApple</pattern>
+    </forceLinkClasses>
+</config>

--- a/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import libcore.io.Base64;
 import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.foundation.NSArray;
 import org.robovm.apple.foundation.NSBundle;
@@ -217,7 +218,13 @@ public class PurchaseManageriOSApple implements PurchaseManager {
         transaction.setReversalText(null);
         
         if (payment.getRequestData() != null) {
-            transaction.setTransactionData(payment.getRequestData().toBase64EncodedString(NSDataBase64EncodingOptions.None));
+            final String transactionData;
+            if (Foundation.getMajorSystemVersion() >= 7) {
+                transactionData = payment.getRequestData().toBase64EncodedString(NSDataBase64EncodingOptions.None);
+            } else {
+                transactionData = Base64.encode(payment.getRequestData().getBytes());
+            }
+            transaction.setTransactionData(transactionData);
         }
         else {
             transaction.setTransactionData(null);
@@ -354,8 +361,7 @@ public class PurchaseManageriOSApple implements PurchaseManager {
                             SKPaymentQueue.getDefaultQueue().finishTransaction(transaction);
                         }
                     } else {
-                        t.setTransactionDataSignature(transaction.getTransactionReceipt().toBase64EncodedString(
-                            NSDataBase64EncodingOptions.None));
+                        t.setTransactionDataSignature(Base64.encode(transaction.getTransactionReceipt().getBytes()));
 
                         log(LOGTYPELOG, "Transaction was completed: " + transaction.getTransactionIdentifier());
 

--- a/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -439,16 +439,19 @@ public class PurchaseManageriOSApple implements PurchaseManager {
 
     @Override
     public Information getInformation(String identifier) {
-        for(SKProduct p : products) {
-            if(p.getProductIdentifier().equals(identifier)) {
-                if(numberFormatter == null) {
-                    numberFormatter = new NSNumberFormatter();
-                    numberFormatter.setFormatterBehavior(NSNumberFormatterBehavior._10_4);
-                    numberFormatter.setNumberStyle(NSNumberFormatterStyle.Currency);
+        if (products != null) {
+            for (SKProduct p : products) {
+                if (p.getProductIdentifier().equals(identifier)) {
+                    if (numberFormatter == null) {
+                        numberFormatter = new NSNumberFormatter();
+                        numberFormatter.setFormatterBehavior(NSNumberFormatterBehavior._10_4);
+                        numberFormatter.setNumberStyle(NSNumberFormatterStyle.Currency);
+                    }
+                    numberFormatter.setLocale(p.getPriceLocale());
+                    Information i = new Information(p.getLocalizedTitle(), p.getLocalizedDescription(),
+                        numberFormatter.format(p.getPrice()));
+                    return i;
                 }
-                numberFormatter.setLocale(p.getPriceLocale());
-                Information i = new Information(p.getLocalizedTitle(), p.getLocalizedDescription(), numberFormatter.format(p.getPrice()));
-                return i;
             }
         }
         return Information.UNAVAILABLE;


### PR DESCRIPTION
Fixes:
1. fix NPE in iOS getInformation: could occure before in gdx-pay code, if PurchaseManager is not installed, but user calls PurchaseSystem.getInformation(...)
2. add robovm.xml to force link classes automatically: now we don't need to ask users to add anything into their robovm.xml (<forceLinkClasses>). Easier setup! :)
3. make PurchaseManageriOSApple work on ios 6: app crashed before, because of absence of some methods on ios6 and earlier