### PR TITLE
Renamed config "custom" to "compileAndIncludeClassesInLibraryJar"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,8 @@ project(":gdx-pay-client") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
@@ -64,8 +64,8 @@ project(":gdx-pay-android") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
@@ -82,16 +82,16 @@ project(":gdx-pay-android-openiab") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
         compile project(':gdx-pay-android')
 
-        custom 'org.onepf:openiab:0.9.8.7'
+        compileAndIncludeClassesInLibraryJar 'org.onepf:openiab:0.9.8.7'
 
-        custom fileTree(dir: 'lib', include: ['*.jar'])
+        compileAndIncludeClassesInLibraryJar fileTree(dir: 'lib', include: ['*.jar'])
     }
 }
 
@@ -100,14 +100,14 @@ project(":gdx-pay-android-ouya") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
         compile project(':gdx-pay-android')
 
-        custom fileTree(dir: 'lib', include: ['*.jar'])
+        compileAndIncludeClassesInLibraryJar fileTree(dir: 'lib', include: ['*.jar'])
     }
 }
 
@@ -116,14 +116,14 @@ project(":gdx-pay-android-amazon") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
         compile project(':gdx-pay-android')
 
-        custom fileTree(dir: 'lib', include: ['*.jar'])
+        compileAndIncludeClassesInLibraryJar fileTree(dir: 'lib', include: ['*.jar'])
     }
 }
 
@@ -132,8 +132,8 @@ project(":gdx-pay-desktop-apple") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
@@ -146,8 +146,8 @@ project(":gdx-pay-gwt-googlewallet") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
@@ -161,8 +161,8 @@ project(":gdx-pay-iosrobovm-apple") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
@@ -177,8 +177,8 @@ project(":gdx-pay-server") {
     apply from : '../publish.gradle'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
@@ -190,8 +190,8 @@ project(":gdx-pay-tests") {
     apply plugin : 'java'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
     }
 
     dependencies {
@@ -205,8 +205,8 @@ project(":gdx-pay-tests-android") {
     apply plugin: 'com.android.application'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
         natives
     }
 
@@ -236,8 +236,8 @@ project(":gdx-pay-tests-iosrobovm") {
     apply plugin: 'robovm'
 
     configurations {
-        custom
-        compile.extendsFrom custom
+        compileAndIncludeClassesInLibraryJar
+        compile.extendsFrom compileAndIncludeClassesInLibraryJar
         natives
     }
 

--- a/gdx-pay-android-googleplay/build.gradle
+++ b/gdx-pay-android-googleplay/build.gradle
@@ -23,8 +23,8 @@ android {
 }
 
 configurations {
-    custom
-    compile.extendsFrom custom
+    compileAndIncludeClassesInLibraryJar
+    compile.extendsFrom compileAndIncludeClassesInLibraryJar
 }
 
 dependencies {
@@ -35,7 +35,7 @@ dependencies {
     compile project(':gdx-pay-client')
     compile "com.google.code.findbugs:jsr305:${jsr305Version}"
 
-    custom fileTree(dir: 'lib', include: ['*.jar'])
+    compileAndIncludeClassesInLibraryJar fileTree(dir: 'lib', include: ['*.jar'])
 }
 
 tasks.withType(Test) {

--- a/gdx-pay/build.gradle
+++ b/gdx-pay/build.gradle
@@ -7,8 +7,8 @@ apply plugin : 'java'
 apply from : '../publish.gradle'
 
 configurations {
-    custom
-    compile.extendsFrom custom
+    compileAndIncludeClassesInLibraryJar
+    compile.extendsFrom compileAndIncludeClassesInLibraryJar
 }
 
 dependencies {

--- a/publish.gradle
+++ b/publish.gradle
@@ -109,7 +109,7 @@ afterEvaluate { project ->
     
     task libraryJar(type: Jar, dependsOn:classes) {
         from sourceSets.main.output.classesDir
-        from configurations.custom.collect { it.isDirectory() ? it : zipTree(it) }
+        from configurations.compileAndIncludeClassesInLibraryJar.collect { it.isDirectory() ? it : zipTree(it) }
         classifier = 'library'
     }
      


### PR DESCRIPTION
The name `custom` did not describe what purpose it had. It was changed to `compileAndIncludeClassesInLibraryJar` to better reflect what it is used for.