### PR TITLE
Removed need for "compileAndIncludeClassesInLibraryJar"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,6 @@ project(":gdx-pay-client") {
     apply plugin : 'java'
     apply from : '../publish.gradle'
 
-    configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
-    }
-
     dependencies {
         compile project(':gdx-pay')
         compile "com.badlogicgames.gdx:gdx:${gdxVersion}"
@@ -66,11 +61,6 @@ project(":gdx-pay-client") {
 project(":gdx-pay-android") {
     apply plugin : 'java'
     apply from : '../publish.gradle'
-
-    configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
-    }
 
     dependencies {
         compile project(':gdx-pay-client')
@@ -135,11 +125,6 @@ project(":gdx-pay-desktop-apple") {
     apply plugin : 'java'
     apply from : '../publish.gradle'
 
-    configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
-    }
-
     dependencies {
         compile project(':gdx-pay-client')
     }
@@ -148,11 +133,6 @@ project(":gdx-pay-desktop-apple") {
 project(":gdx-pay-gwt-googlewallet") {
     apply plugin : 'java'
     apply from : '../publish.gradle'
-
-    configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
-    }
 
     dependencies {
         compile project(':gdx-pay-client')
@@ -163,11 +143,6 @@ project(":gdx-pay-iosrobovm-apple") {
     apply plugin : 'java'
     apply plugin : 'robovm'
     apply from : '../publish.gradle'
-
-    configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
-    }
 
     dependencies {
         compile project(':gdx-pay-client')
@@ -180,11 +155,6 @@ project(":gdx-pay-server") {
     apply plugin : 'java'
     apply from : '../publish.gradle'
 
-    configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
-    }
-
     dependencies {
         compile project(':gdx-pay')
     }
@@ -192,11 +162,6 @@ project(":gdx-pay-server") {
 
 project(":gdx-pay-tests") {
     apply plugin : 'java'
-
-    configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
-    }
 
     dependencies {
         compile project(':gdx-pay-client')
@@ -209,8 +174,6 @@ project(":gdx-pay-tests-android") {
     apply plugin: 'com.android.application'
 
     configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
         natives
     }
 
@@ -240,8 +203,6 @@ project(":gdx-pay-tests-iosrobovm") {
     apply plugin: 'robovm'
 
     configurations {
-        compileAndIncludeClassesInLibraryJar
-        compile.extendsFrom compileAndIncludeClassesInLibraryJar
         natives
     }
 

--- a/gdx-pay/build.gradle
+++ b/gdx-pay/build.gradle
@@ -6,11 +6,6 @@ targetCompatibility = 1.6
 apply plugin : 'java'
 apply from : '../publish.gradle'
 
-configurations {
-    compileAndIncludeClassesInLibraryJar
-    compile.extendsFrom compileAndIncludeClassesInLibraryJar
-}
-
 dependencies {
     testCompile "junit:junit:${junitVersion}"
     testCompile "org.assertj:assertj-core:${assertJVersion}"

--- a/publish.gradle
+++ b/publish.gradle
@@ -109,7 +109,9 @@ afterEvaluate { project ->
     
     task libraryJar(type: Jar, dependsOn:classes) {
         from sourceSets.main.output.classesDir
-        from configurations.compileAndIncludeClassesInLibraryJar.collect { it.isDirectory() ? it : zipTree(it) }
+        if (configurations.findByName('compileAndIncludeClassesInLibraryJar') != null) {
+            from configurations.compileAndIncludeClassesInLibraryJar.collect { it.isDirectory() ? it : zipTree(it) }
+        }
         classifier = 'library'
     }
      


### PR DESCRIPTION
Changed so `publish.gradle` detects if a project has configuration `compileAndIncludeClassesInLibraryJar`, and if so behaves as before. If the configuration is not present, no third-party classes are added to the library JAR.