### PR TITLE
Robovm purchase information with currency code

### DIFF
--- a/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -514,8 +514,12 @@ public class PurchaseManageriOSApple implements PurchaseManager {
                         numberFormatter.setNumberStyle(NSNumberFormatterStyle.Currency);
                     }
                     numberFormatter.setLocale(p.getPriceLocale());
-                    return new Information(p.getLocalizedTitle(), p.getLocalizedDescription(),
-                numberFormatter.format(p.getPrice()));
+                    return Information.newBuilder()
+                        .localName(p.getLocalizedTitle())
+                        .localDescription(p.getLocalizedDescription())
+                        .localPricing(numberFormatter.format(p.getPrice()))
+                        .priceCurrencyCode(p.getPriceLocale().getCurrencyCode())
+                        .build();
                 }
             }
         }


### PR DESCRIPTION
In robovm-iOS the retrieved information about a purchase always had null currency code. 
I edited the code to built the Information with the given builder instead of the basic constructor.