### PR TITLE
gdx-pay-android-amazon: Fix project setup

### DIFF
--- a/gdx-pay-android-amazon/AndroidManifest.xml
+++ b/gdx-pay-android-amazon/AndroidManifest.xml
@@ -1,10 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
           package="com.badlogic.gdx.pay.android.amazon">
 
     <application>
 
         <!-- IAP -->
-        <receiver android:name="com.amazon.device.iap.ResponseReceiver">
+        <receiver
+            android:name="com.amazon.device.iap.ResponseReceiver"
+            tools:ignore="ExportedReceiver,InvalidPermission">
             <intent-filter>
                 <action
                     android:name="com.amazon.inapp.purchasing.NOTIFY"

--- a/gdx-pay-android-amazon/AndroidManifest.xml
+++ b/gdx-pay-android-amazon/AndroidManifest.xml
@@ -1,4 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.badlogic.gdx.pay.android.amazon">
+          package="com.badlogic.gdx.pay.android.amazon">
+
+    <application>
+
+        <!-- IAP -->
+        <receiver android:name="com.amazon.device.iap.ResponseReceiver">
+            <intent-filter>
+                <action
+                    android:name="com.amazon.inapp.purchasing.NOTIFY"
+                    android:permission="com.amazon.inapp.purchasing.Permission.NOTIFY"
+                    />
+            </intent-filter>
+        </receiver>
+
+    </application>
 
 </manifest>

--- a/gdx-pay-android-amazon/AndroidManifest.xml
+++ b/gdx-pay-android-amazon/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.badlogic.gdx.pay.android.amazon">
+
+</manifest>

--- a/gdx-pay-android-amazon/README.md
+++ b/gdx-pay-android-amazon/README.md
@@ -1,0 +1,20 @@
+# InApp purchasing implementation for Amazon
+
+Handles purchases and restores for non-consumable and consumable products, will not work as intended for subscriptions.
+
+## proguard configuration
+
+     #IAP
+     -dontwarn com.amazon.**
+     -keep class com.amazon.** {*;}
+     -keepattributes *Annotation*
+     -optimizations !code/allocation/variable
+
+## Testing
+* Draft some IAPs in Amazon's developer console
+* Export them as JSON and copy the file to your Amazon device
+* Download App Tester vom Amazon App Store
+* Use your debug build to test
+* When done, compile your release build and submit it for live app testing
+* Submit your IAPs
+* Your live app testers can test the "real" behaviour without being charged

--- a/gdx-pay-android-amazon/build.gradle
+++ b/gdx-pay-android-amazon/build.gradle
@@ -1,13 +1,30 @@
-apply plugin : 'java'
-apply from : '../publish_java.gradle'
+apply plugin: 'com.android.library'
+apply from : '../publish_android.gradle'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-sourceSets {
-    main {
-        java {
-            srcDir 'src'
+android {
+    defaultPublishConfig "release"
+
+    compileSdkVersion androidCompileSdkVersion
+    buildToolsVersion androidBuildToolsVersion
+
+    defaultConfig {
+        minSdkVersion androidMinimalSdkVersion
+        targetSdkVersion androidTargetSdkVersion
+        testInstrumentationRunner "android.test.InstrumentationTestRunner"
+        testOptions {
+            unitTests.returnDefaultValues = true
+        }
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java {
+                srcDir 'src'
+            }
         }
     }
 }

--- a/gdx-pay-android-amazon/src/com/badlogic/gdx/pay/android/amazon/PurchaseManagerAndroidAmazon.java
+++ b/gdx-pay-android-amazon/src/com/badlogic/gdx/pay/android/amazon/PurchaseManagerAndroidAmazon.java
@@ -49,11 +49,9 @@ import android.os.Message;
 import android.util.Log;
 import android.widget.Toast;
 
-/** The purchase manager implementation for OUYA.
+/** The purchase manager implementation for Amazon.
  * <p>
- * Include the gdx-pay-android-ouya.jar for this to work (plus gdx-pay-android.jar). Also update the "uses-permission" settings in
- * AndroidManifest.xml and your proguard settings.
- * 
+ *
  * @author just4phil */
 public class PurchaseManagerAndroidAmazon implements PurchaseManager, PurchasingListener {
 

--- a/gdx-pay-android-amazon/src/com/badlogic/gdx/pay/android/amazon/PurchaseManagerAndroidAmazon.java
+++ b/gdx-pay-android-amazon/src/com/badlogic/gdx/pay/android/amazon/PurchaseManagerAndroidAmazon.java
@@ -51,6 +51,7 @@ import android.widget.Toast;
 
 /** The purchase manager implementation for Amazon.
  * <p>
+ * See https://developer.amazon.com/de/docs/in-app-purchasing/iap-implement-iap.html
  *
  * @author just4phil */
 public class PurchaseManagerAndroidAmazon implements PurchaseManager, PurchasingListener {
@@ -255,10 +256,7 @@ public class PurchaseManagerAndroidAmazon implements PurchaseManager, Purchasing
 
 
     /**
-     * This is the callback for {@link PurchasingService#getUserData}. For
-     * successful case, get the current user from {@link UserDataResponse} and
-     * call {@link SampleIAPManager#setAmazonUserId} method to load the Amazon
-     * user and related purchase information
+     * This is the callback for {@link PurchasingService#getUserData}.
      *
      * @param response
      */
@@ -408,11 +406,7 @@ public class PurchaseManagerAndroidAmazon implements PurchaseManager, Purchasing
      * This is the callback for {@link PurchasingService#purchase}. For each
      * time the application sends a purchase request
      * {@link PurchasingService#purchase}, Amazon Appstore will call this
-     * callback when the purchase request is completed. If the RequestStatus is
-     * Successful or AlreadyPurchased then application needs to call
-     * {@link SampleIAPManager#handleReceipt} to handle the purchase
-     * fulfillment. If the RequestStatus is INVALID_SKU, NOT_SUPPORTED, or
-     * FAILED, notify corresponding method of {@link SampleIAPManager} .
+     * callback when the purchase request is completed.
      */
     @Override
     public void onPurchaseResponse(final PurchaseResponse response) {


### PR DESCRIPTION
It was not possible to import gdx-pay-android-amazon with gradle because it was no Android library project.

Hence, the following error was thrown when running a game using PurchaseManagerAndroidAmazon:

java.lang.NoClassDefFoundError: com.badlogic.gdx.pay.android.amazon.PurchaseManagerAndroidAmazon

This commit fixes the project setup.