### PR TITLE
Fix convertJSONPurchaseToTransaction not handling null data

### DIFF
--- a/gdx-pay-android-googleplay/src/main/java/com/badlogic/gdx/pay/android/googleplay/billing/converter/InAppPurchaseDataToTransactionConverter.java
+++ b/gdx-pay-android-googleplay/src/main/java/com/badlogic/gdx/pay/android/googleplay/billing/converter/InAppPurchaseDataToTransactionConverter.java
@@ -24,6 +24,10 @@ public class InAppPurchaseDataToTransactionConverter {
 
     // See http://developer.android.com/google/play/billing/billing_reference.html#purchase-data-table
     public static Transaction convertJSONPurchaseToTransaction(String inAppPurchaseData) throws JSONException {
+        if (inAppPurchaseData == null) {
+            // this can happen when purchase was cancelled, ie for test product id 'android.test.canceled'
+            throw new JSONException("inAppPurchaseData was null.");
+        }
         JSONObject object = new JSONObject(inAppPurchaseData);
 
         Transaction transaction = new Transaction();

--- a/gdx-pay-server/src/com/badlogic/gdx/pay/server/impl/PurchaseVerifieriOSApple.java
+++ b/gdx-pay-server/src/com/badlogic/gdx/pay/server/impl/PurchaseVerifieriOSApple.java
@@ -82,7 +82,16 @@ public class PurchaseVerifieriOSApple implements PurchaseVerifier {
 			rd.close();
 			
 			// verify the response: something like {"status":21004} etc...
-			int status = Integer.parseInt(line.substring(line.indexOf(":") + 1, line.indexOf("}")));
+			final String search = "\"status\":";
+			int start = line.indexOf(search) + search.length();
+			while (Character.isWhitespace(line.charAt(start))) {
+				start++;
+			}
+			int end = start + 1;
+			while (Character.isDigit(line.charAt(end))) {
+				end++;
+			}
+			int status = Integer.parseInt(line.substring(start, end));
 			switch (status) {
 				case 0: return true;
 				case 21000: System.out.println(status + ": App store could not read"); return false;
@@ -101,7 +110,11 @@ public class PurchaseVerifieriOSApple implements PurchaseVerifier {
 		} catch (IOException e) {
 			// I/O-error: let's assume bad news...
 			System.err.println("I/O error during verification: " + e);
-			e.printStackTrace();			
+			e.printStackTrace();
+			return false;
+		} catch (NumberFormatException e) {
+			System.err.println("Status extraction failed: " + e);
+			e.printStackTrace();
 			return false;
 		}
 	}


### PR DESCRIPTION
Fix consist of throwing JSONException when data is null, causing the purchase to fail. This can easily be tested by trying to purchase 'android.test.canceled'. 
See #163 and #137.