### PR TITLE
Expose precise price to clients

### DIFF
--- a/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
+++ b/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
@@ -1,41 +1,13 @@
 package com.badlogic.gdx.pay.android.googlebilling;
 
 import android.app.Activity;
-
-import com.android.billingclient.api.AcknowledgePurchaseParams;
-import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
-import com.android.billingclient.api.BillingClient;
-import com.android.billingclient.api.BillingClientStateListener;
-import com.android.billingclient.api.BillingFlowParams;
-import com.android.billingclient.api.BillingResult;
-import com.android.billingclient.api.ConsumeParams;
-import com.android.billingclient.api.ConsumeResponseListener;
-import com.android.billingclient.api.Purchase;
-import com.android.billingclient.api.PurchasesUpdatedListener;
-import com.android.billingclient.api.SkuDetails;
-import com.android.billingclient.api.SkuDetailsParams;
-import com.android.billingclient.api.SkuDetailsResponseListener;
+import com.android.billingclient.api.*;
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.pay.FetchItemInformationException;
-import com.badlogic.gdx.pay.GdxPayException;
-import com.badlogic.gdx.pay.Information;
-import com.badlogic.gdx.pay.InvalidItemException;
-import com.badlogic.gdx.pay.ItemAlreadyOwnedException;
-import com.badlogic.gdx.pay.Offer;
-import com.badlogic.gdx.pay.OfferType;
-import com.badlogic.gdx.pay.PurchaseManager;
-import com.badlogic.gdx.pay.PurchaseManagerConfig;
-import com.badlogic.gdx.pay.PurchaseObserver;
-import com.badlogic.gdx.pay.Transaction;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import com.badlogic.gdx.pay.*;
 
 import javax.annotation.Nullable;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The purchase manager implementation for Google Play (Android) using Google Billing Library
@@ -200,7 +172,8 @@ public class PurchaseManagerGoogleBilling implements PurchaseManager, PurchasesU
                 .localDescription(skuDetails.getDescription())
                 .localPricing(priceString)
                 .priceCurrencyCode(skuDetails.getPriceCurrencyCode())
-                .priceInCents((int) (skuDetails.getPriceAmountMicros() / 10000))
+                .priceInCents((int) (skuDetails.getPriceAmountMicros() / 10_000))
+                .priceAsDouble(skuDetails.getPriceAmountMicros() / 1_000_000.0)
                 .build();
     }
 

--- a/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManagerUtils.java
+++ b/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManagerUtils.java
@@ -52,7 +52,8 @@ class HuaweiPurchaseManagerUtils {
                 .localDescription(productInfo.getProductDesc())
                 .localPricing(priceString)
                 .priceCurrencyCode(productInfo.getCurrency())
-                .priceInCents((int) (productInfo.getMicrosPrice() / 10000))
+                .priceInCents((int) (productInfo.getMicrosPrice() / 10_000))
+                .priceAsDouble(productInfo.getMicrosPrice() / 1_000_000.0)
                 .build();
     }
 

--- a/gdx-pay-iosmoe-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosmoe-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -16,45 +16,23 @@
 
 package com.badlogic.gdx.pay.ios.apple;
 
-import com.badlogic.gdx.pay.Information;
-import com.badlogic.gdx.pay.InvalidItemException;
-import com.badlogic.gdx.pay.Offer;
-import com.badlogic.gdx.pay.PurchaseManager;
-import com.badlogic.gdx.pay.PurchaseManagerConfig;
-import com.badlogic.gdx.pay.PurchaseObserver;
-import com.badlogic.gdx.pay.Transaction;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
-import apple.foundation.NSArray;
-import apple.foundation.NSBundle;
-import apple.foundation.NSData;
-import apple.foundation.NSDate;
-import apple.foundation.NSError;
-import apple.foundation.NSLocale;
-import apple.foundation.NSMutableSet;
-import apple.foundation.NSNumberFormatter;
-import apple.foundation.NSURL;
+import apple.foundation.*;
 import apple.foundation.enums.NSNumberFormatterBehavior;
 import apple.foundation.enums.NSNumberFormatterStyle;
-import apple.storekit.SKPayment;
-import apple.storekit.SKPaymentQueue;
-import apple.storekit.SKPaymentTransaction;
-import apple.storekit.SKProduct;
-import apple.storekit.SKProductsRequest;
-import apple.storekit.SKProductsResponse;
-import apple.storekit.SKReceiptRefreshRequest;
-import apple.storekit.SKRequest;
+import apple.storekit.*;
 import apple.storekit.enums.SKErrorCode;
 import apple.storekit.enums.SKPaymentTransactionState;
 import apple.storekit.protocol.SKPaymentTransactionObserver;
 import apple.storekit.protocol.SKProductsRequestDelegate;
 import apple.storekit.protocol.SKRequestDelegate;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.pay.*;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
 
 import static apple.foundation.c.Foundation.NSLocaleCurrencyCode;
 
@@ -408,6 +386,8 @@ public class PurchaseManageriOSApple implements PurchaseManager, SKPaymentTransa
 
                             // p.priceLocale().currencyCode() is not supported on iOS 9
                             .priceCurrencyCode(String.valueOf(p.priceLocale().objectForKey("CurrencyCode")))
+                            .priceInCents(MathUtils.ceilPositive(p.price().floatValue() * 100))
+                            .priceAsDouble(p.price().doubleValue())
                             .build();
 
                 }

--- a/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -16,47 +16,17 @@
 
 package com.badlogic.gdx.pay.ios.apple;
 
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.pay.*;
+import libcore.io.Base64;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.storekit.*;
+
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import javax.annotation.Nullable;
-
-import org.robovm.apple.foundation.Foundation;
-import org.robovm.apple.foundation.NSArray;
-import org.robovm.apple.foundation.NSBundle;
-import org.robovm.apple.foundation.NSData;
-import org.robovm.apple.foundation.NSDataBase64EncodingOptions;
-import org.robovm.apple.foundation.NSError;
-import org.robovm.apple.foundation.NSNumberFormatter;
-import org.robovm.apple.foundation.NSNumberFormatterBehavior;
-import org.robovm.apple.foundation.NSNumberFormatterStyle;
-import org.robovm.apple.foundation.NSURL;
-import org.robovm.apple.storekit.SKErrorCode;
-import org.robovm.apple.storekit.SKPayment;
-import org.robovm.apple.storekit.SKPaymentQueue;
-import org.robovm.apple.storekit.SKPaymentTransaction;
-import org.robovm.apple.storekit.SKPaymentTransactionObserverAdapter;
-import org.robovm.apple.storekit.SKPaymentTransactionState;
-import org.robovm.apple.storekit.SKProduct;
-import org.robovm.apple.storekit.SKProductsRequest;
-import org.robovm.apple.storekit.SKProductsRequestDelegateAdapter;
-import org.robovm.apple.storekit.SKProductsResponse;
-import org.robovm.apple.storekit.SKReceiptRefreshRequest;
-import org.robovm.apple.storekit.SKRequest;
-import org.robovm.apple.storekit.SKRequestDelegateAdapter;
-
-import com.badlogic.gdx.pay.FetchItemInformationException;
-import com.badlogic.gdx.pay.GdxPayException;
-import com.badlogic.gdx.pay.Information;
-import com.badlogic.gdx.pay.Offer;
-import com.badlogic.gdx.pay.PurchaseManager;
-import com.badlogic.gdx.pay.PurchaseManagerConfig;
-import com.badlogic.gdx.pay.PurchaseObserver;
-import com.badlogic.gdx.pay.Transaction;
-
-import libcore.io.Base64;
 
 /** The purchase manager implementation for Apple's iOS IAP system (RoboVM).
  *
@@ -562,6 +532,8 @@ public class PurchaseManageriOSApple implements PurchaseManager {
                         .localDescription(p.getLocalizedDescription())
                         .localPricing(numberFormatter.format(p.getPrice()))
                         .priceCurrencyCode(p.getPriceLocale().getCurrencyCode())
+                        .priceInCents(MathUtils.ceilPositive(p.getPrice().floatValue() * 100))
+                        .priceAsDouble(p.getPrice().doubleValue())
                         .build();
                 }
             }

--- a/gdx-pay/src/main/java/com/badlogic/gdx/pay/Information.java
+++ b/gdx-pay/src/main/java/com/badlogic/gdx/pay/Information.java
@@ -1,6 +1,7 @@
 package com.badlogic.gdx.pay;
 
 import javax.annotation.Nullable;
+import java.util.Currency;
 
 /**
  * Information about a product that can be purchased provided by a purchase manager. Some methods
@@ -19,7 +20,13 @@ public final class Information {
     private String localDescription;
     private String localPricing;
 
+    /**
+     * @deprecated Not all currencies use cents. Currencies with no or more than 2 fractional
+     * digits exist. Use {@link #priceAsDouble} instead.
+     */
+    @Deprecated
     private Integer priceInCents;
+    private Double priceAsDouble;
 
     private String priceCurrencyCode;
 
@@ -34,6 +41,7 @@ public final class Information {
         localDescription = builder.localDescription;
         localPricing = builder.localPricing;
         priceInCents = builder.priceInCents;
+        priceAsDouble = builder.priceAsDouble;
         priceCurrencyCode = builder.priceCurrencyCode;
     }
 
@@ -44,10 +52,35 @@ public final class Information {
     /**
      * Price in cents.
      * <p>Caution: this field could be null, information is not always available! </p>
+     *
+     * @deprecated Not all currencies use cents. Currencies with no or more than 2 fractional
+     * digits exist. Use {@link #getPriceAsDouble()} instead.
      */
+    @Deprecated
     @Nullable
     public Integer getPriceInCents() {
         return priceInCents;
+    }
+
+    /**
+     * Price (as a double).
+     * <p>Caution: this field could be null, information is not always available! </p>
+     * <p>Use {@link Currency#getDefaultFractionDigits()} to format the price with the correct
+     * number of fraction digits for its currency:</p>
+     * <pre>
+     * NumberFormat priceFormat = NumberFormat.getCurrencyInstance(yourUsersLocale);
+     * Currency currency = Currency.getInstance(information.getCurrencyCode());
+     * priceFormat.setCurrency(currency);
+     * priceFormat.setMaximumFractionDigits(currency.getDefaultFractionDigits());
+     * priceFormat.setMinimumFractionDigits(currency.getDefaultFractionDigits());
+     * priceFormat.format(information.getPriceAsDouble());
+     * </pre>
+     * <p>Note that this will not always output the currency symbol (e.g. €), but use the
+     * currency code (e.g. EUR) instead.</p>
+     */
+    @Nullable
+    public Double getPriceAsDouble() {
+        return priceAsDouble;
     }
 
     /**
@@ -116,7 +149,13 @@ public final class Information {
         private String localName;
         private String localDescription;
         private String localPricing;
+        /**
+         * @deprecated Not all currencies use cents. Currencies with no or more than 2 fractional
+         * digits exist. Use {@link #priceAsDouble} instead.
+         */
+        @Deprecated
         private Integer priceInCents;
+        private Double priceAsDouble;
         private String priceCurrencyCode;
 
         private Builder() {
@@ -137,8 +176,18 @@ public final class Information {
             return this;
         }
 
+        /**
+         * @deprecated Not all currencies use cents. Currencies with no or more than 2 fractional
+         * digits exist. Use {@link #priceAsDouble(Double)} instead.
+         */
+        @Deprecated
         public Builder priceInCents(Integer val) {
             priceInCents = val;
+            return this;
+        }
+
+        public Builder priceAsDouble(Double val) {
+            priceAsDouble = val;
             return this;
         }
 


### PR DESCRIPTION
Added price (as double) to the information object. Changed providers to also fill this field (if the information is available). Deprecated the price in cents as it is not precise enough for some currencies