### PR TITLE
Prevent crash for undefined/null transaction date

### DIFF
--- a/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -207,8 +207,8 @@ public class PurchaseManageriOSApple implements PurchaseManager {
 
         transaction.setStoreName(PurchaseManagerConfig.STORE_NAME_IOS_APPLE);
         transaction.setOrderId(getOriginalTxID(t));
-	    
-	NSDate date = t.getTransactionDate();
+
+        NSDate date = t.getTransactionDate();
         if (date == null) {
             // According to https://developer.apple.com/documentation/storekit/skpaymenttransaction/1411273-transactiondate
             // transaction date cannot be undefined/null for purchased or restored items


### PR DESCRIPTION
According to https://developer.apple.com/documentation/storekit/skpaymenttransaction/1411273-transactiondate transaction date cannot be undefined/null for purchased or restored items.

In my experience date is null only for hacked transactions so considering them as invalid seems to be the right approach. Prior to this change the app would just crash if date is null which could lead to bad reviews (yeah, how dare it to crash for hackers...).

Associated issue: https://github.com/libgdx/gdx-pay/issues/219