### PR TITLE
#220 support free trial period for subscriptions

### DIFF
--- a/gdx-pay-android-googlebilling/build.gradle
+++ b/gdx-pay-android-googlebilling/build.gradle
@@ -24,6 +24,11 @@ android {
                 srcDir 'src'
             }
         }
+        test {
+            java {
+                srcDir 'test'
+            }
+        }
     }
 }
 
@@ -39,4 +44,6 @@ repositories {
 dependencies {
     compile project(':gdx-pay-client')
     compile 'com.android.billingclient:billing:3.0.0'
+
+    testCompile libraries.junit
 }

--- a/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverter.java
+++ b/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverter.java
@@ -1,0 +1,23 @@
+package com.badlogic.gdx.pay.android.googlebilling;
+
+import com.badlogic.gdx.pay.FreeTrialPeriod;
+
+import javax.annotation.Nonnull;
+
+import static com.badlogic.gdx.pay.FreeTrialPeriod.PeriodUnit.*;
+
+class Iso8601DurationStringToFreeTrialPeriodConverter {
+
+    /**
+     * <p>See also:
+     * <a href="https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm">
+     *                        the spec</a>
+     */
+    @Nonnull
+    public static FreeTrialPeriod convertToFreeTrialPeriod(@Nonnull String iso8601Duration) {
+        int numberOfUnits = Integer.parseInt(iso8601Duration.substring(1, iso8601Duration.length() -1 ));
+        final FreeTrialPeriod.PeriodUnit unit = parse(iso8601Duration.substring(iso8601Duration.length() - 1).charAt(0));
+
+        return new FreeTrialPeriod(numberOfUnits, unit);
+    }
+}

--- a/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverter.java
+++ b/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverter.java
@@ -1,10 +1,10 @@
 package com.badlogic.gdx.pay.android.googlebilling;
 
 import com.badlogic.gdx.pay.FreeTrialPeriod;
+import com.badlogic.gdx.pay.FreeTrialPeriod.PeriodUnit;
 
 import javax.annotation.Nonnull;
 
-import static com.badlogic.gdx.pay.FreeTrialPeriod.PeriodUnit.*;
 
 class Iso8601DurationStringToFreeTrialPeriodConverter {
 
@@ -15,8 +15,8 @@ class Iso8601DurationStringToFreeTrialPeriodConverter {
      */
     @Nonnull
     public static FreeTrialPeriod convertToFreeTrialPeriod(@Nonnull String iso8601Duration) {
-        int numberOfUnits = Integer.parseInt(iso8601Duration.substring(1, iso8601Duration.length() -1 ));
-        final FreeTrialPeriod.PeriodUnit unit = parse(iso8601Duration.substring(iso8601Duration.length() - 1).charAt(0));
+        final int numberOfUnits = Integer.parseInt(iso8601Duration.substring(1, iso8601Duration.length() -1 ));
+        final PeriodUnit unit = PeriodUnit.parse(iso8601Duration.substring(iso8601Duration.length() - 1).charAt(0));
 
         return new FreeTrialPeriod(numberOfUnits, unit);
     }

--- a/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
+++ b/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
@@ -10,8 +10,6 @@ import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.badlogic.gdx.pay.android.googlebilling.Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod;
-
 /**
  * The purchase manager implementation for Google Play (Android) using Google Billing Library
  * <p>
@@ -172,7 +170,7 @@ public class PurchaseManagerGoogleBilling implements PurchaseManager, PurchasesU
         String priceString = skuDetails.getPrice();
         return Information.newBuilder()
                 .localName(skuDetails.getTitle())
-                .freeTrialPeriod(parseFreeTrial(skuDetails.getFreeTrialPeriod()))
+                .freeTrialPeriod(convertToFreeTrialPeriod(skuDetails.getFreeTrialPeriod()))
                 .localDescription(skuDetails.getDescription())
                 .localPricing(priceString)
                 .priceCurrencyCode(skuDetails.getPriceCurrencyCode())
@@ -185,13 +183,13 @@ public class PurchaseManagerGoogleBilling implements PurchaseManager, PurchasesU
      * @param iso8601Duration in ISO 8601 format.
      */
     @Nullable
-    private FreeTrialPeriod parseFreeTrial(@Nullable  String iso8601Duration) {
+    private FreeTrialPeriod convertToFreeTrialPeriod(@Nullable  String iso8601Duration) {
         if (iso8601Duration == null || iso8601Duration.isEmpty()) {
             return null;
         }
 
         try {
-            return convertToFreeTrialPeriod(iso8601Duration);
+            return Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod(iso8601Duration);
         } catch(RuntimeException e) {
             Gdx.app.error(TAG, "Failed to parse iso8601Duration: " + iso8601Duration, e);
             return null;

--- a/gdx-pay-android-googlebilling/test/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverterTest.java
+++ b/gdx-pay-android-googlebilling/test/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverterTest.java
@@ -1,0 +1,49 @@
+package com.badlogic.gdx.pay.android.googlebilling;
+
+import com.badlogic.gdx.pay.FreeTrialPeriod;
+import com.badlogic.gdx.pay.FreeTrialPeriod.PeriodUnit;
+import org.junit.Test;
+
+import static com.badlogic.gdx.pay.android.googlebilling.Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod;
+import static org.junit.Assert.*;
+
+public class Iso8601DurationStringToFreeTrialPeriodConverterTest {
+
+    @Test
+    public void convertsStringWithFewDays() {
+
+        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P3D");
+
+        assertEquals(3, duration.getNumberOfUnits());
+        assertEquals(PeriodUnit.DAY, duration.getUnit());
+    }
+
+    @Test
+    public void convertsStringWithMoreThenTenDays() {
+
+        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P14D");
+
+        assertEquals(14, duration.getNumberOfUnits());
+        assertEquals(PeriodUnit.DAY, duration.getUnit());
+    }
+
+    @Test
+    public void convertsStringWitSixMonths() {
+
+        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P6M");
+
+        assertEquals(6, duration.getNumberOfUnits());
+        assertEquals(PeriodUnit.MONTH, duration.getUnit());
+    }
+
+    @Test
+    public void convertsStringWithOneYear() {
+
+        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P1Y");
+
+        assertEquals(1, duration.getNumberOfUnits());
+        assertEquals(PeriodUnit.YEAR, duration.getUnit());
+    }
+
+
+}

--- a/gdx-pay-android-googlebilling/test/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverterTest.java
+++ b/gdx-pay-android-googlebilling/test/com/badlogic/gdx/pay/android/googlebilling/Iso8601DurationStringToFreeTrialPeriodConverterTest.java
@@ -4,7 +4,6 @@ import com.badlogic.gdx.pay.FreeTrialPeriod;
 import com.badlogic.gdx.pay.FreeTrialPeriod.PeriodUnit;
 import org.junit.Test;
 
-import static com.badlogic.gdx.pay.android.googlebilling.Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod;
 import static org.junit.Assert.*;
 
 public class Iso8601DurationStringToFreeTrialPeriodConverterTest {
@@ -12,37 +11,37 @@ public class Iso8601DurationStringToFreeTrialPeriodConverterTest {
     @Test
     public void convertsStringWithFewDays() {
 
-        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P3D");
+        final FreeTrialPeriod period = Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod("P3D");
 
-        assertEquals(3, duration.getNumberOfUnits());
-        assertEquals(PeriodUnit.DAY, duration.getUnit());
+        assertEquals(3, period.getNumberOfUnits());
+        assertEquals(PeriodUnit.DAY, period.getUnit());
     }
 
     @Test
     public void convertsStringWithMoreThenTenDays() {
 
-        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P14D");
+        final FreeTrialPeriod period = Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod("P14D");
 
-        assertEquals(14, duration.getNumberOfUnits());
-        assertEquals(PeriodUnit.DAY, duration.getUnit());
+        assertEquals(14, period.getNumberOfUnits());
+        assertEquals(PeriodUnit.DAY, period.getUnit());
     }
 
     @Test
     public void convertsStringWitSixMonths() {
 
-        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P6M");
+        final FreeTrialPeriod period = Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod("P6M");
 
-        assertEquals(6, duration.getNumberOfUnits());
-        assertEquals(PeriodUnit.MONTH, duration.getUnit());
+        assertEquals(6, period.getNumberOfUnits());
+        assertEquals(PeriodUnit.MONTH, period.getUnit());
     }
 
     @Test
     public void convertsStringWithOneYear() {
 
-        final FreeTrialPeriod duration = convertToFreeTrialPeriod("P1Y");
+        final FreeTrialPeriod period = Iso8601DurationStringToFreeTrialPeriodConverter.convertToFreeTrialPeriod("P1Y");
 
-        assertEquals(1, duration.getNumberOfUnits());
-        assertEquals(PeriodUnit.YEAR, duration.getUnit());
+        assertEquals(1, period.getNumberOfUnits());
+        assertEquals(PeriodUnit.YEAR, period.getUnit());
     }
 
 

--- a/gdx-pay-iosmoe-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosmoe-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.pay.ios.apple;
 
 import apple.foundation.*;
+import apple.foundation.c.Foundation;
 import apple.foundation.enums.NSNumberFormatterBehavior;
 import apple.foundation.enums.NSNumberFormatterStyle;
 import apple.storekit.*;
@@ -33,8 +34,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-
-import static apple.foundation.c.Foundation.NSLocaleCurrencyCode;
 
 /** The purchase manager implementation for Apple's iOS IAP system (iOS-MOE).
  *
@@ -234,7 +233,7 @@ public class PurchaseManageriOSApple implements PurchaseManager, SKPaymentTransa
             transaction.setPurchaseText("Purchased: " + product.localizedTitle());
             transaction.setPurchaseCost((int) Math.round(product.price().doubleValue() * 100));
             NSLocale locale = product.priceLocale();
-            transaction.setPurchaseCostCurrency((String) locale.objectForKey(NSLocaleCurrencyCode()));
+            transaction.setPurchaseCostCurrency((String) locale.objectForKey(Foundation.NSLocaleCurrencyCode()));
         } else {
             // product information was empty (not loaded or product didn't exist)
             transaction.setPurchaseText("Purchased: " + productIdentifier);

--- a/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -28,8 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.badlogic.gdx.pay.ios.apple.SKProductPeriodUnitToPeriodUnitConverter.convertToPeriodUnit;
-
 /** The purchase manager implementation for Apple's iOS IAP system (RoboVM).
  *
  * @author HD_92 (BlueRiverInteractive)
@@ -536,7 +534,7 @@ public class PurchaseManageriOSApple implements PurchaseManager {
                         .priceCurrencyCode(p.getPriceLocale().getCurrencyCode())
                         .priceInCents(MathUtils.ceilPositive(p.getPrice().floatValue() * 100))
                         .priceAsDouble(p.getPrice().doubleValue())
-                        .freeTrialPeriod(freeTrialPeriod(p))
+                        .freeTrialPeriod(convertToFreeTrialPeriod(p))
                         .build();
                 }
             }
@@ -544,19 +542,22 @@ public class PurchaseManageriOSApple implements PurchaseManager {
         return Information.UNAVAILABLE;
     }
 
-    private FreeTrialPeriod freeTrialPeriod(SKProduct product) {
+    private FreeTrialPeriod convertToFreeTrialPeriod(SKProduct product) {
         final SKProductDiscount introductoryPrice = product.getIntroductoryPrice();
         if (introductoryPrice == null || introductoryPrice.getSubscriptionPeriod() == null || introductoryPrice.getSubscriptionPeriod().getNumberOfUnits() == 0) {
             return null;
         }
 
-        if (introductoryPrice.getPrice() != null && introductoryPrice.getPrice().doubleValue() > 0f) {
+        if (introductoryPrice.getPrice() != null && introductoryPrice.getPrice().doubleValue() > 0D) {
             // in that case, it is not a free trial. We do not yet support reduced price introductory offers.
             return null;
         }
 
         final SKProductSubscriptionPeriod subscriptionPeriod = introductoryPrice.getSubscriptionPeriod();
-        return new FreeTrialPeriod( (int) subscriptionPeriod.getNumberOfUnits(), convertToPeriodUnit(subscriptionPeriod.getUnit()));
+        return new FreeTrialPeriod(
+                (int) subscriptionPeriod.getNumberOfUnits(),
+                SKProductPeriodUnitToPeriodUnitConverter.convertToPeriodUnit(subscriptionPeriod.getUnit())
+        );
     }
 
     @Override

--- a/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/SKProductPeriodUnitToPeriodUnitConverter.java
+++ b/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/SKProductPeriodUnitToPeriodUnitConverter.java
@@ -1,0 +1,25 @@
+package com.badlogic.gdx.pay.ios.apple;
+
+import com.badlogic.gdx.pay.FreeTrialPeriod;
+import org.robovm.apple.storekit.SKProductPeriodUnit;
+
+import java.util.HashMap;
+import java.util.Map;
+
+enum SKProductPeriodUnitToPeriodUnitConverter {
+    ;
+
+    private static final Map<SKProductPeriodUnit, FreeTrialPeriod.PeriodUnit> appleToGdxUnitMap = new HashMap<SKProductPeriodUnit, FreeTrialPeriod.PeriodUnit>();
+
+    static {
+        appleToGdxUnitMap.put(SKProductPeriodUnit.Day, FreeTrialPeriod.PeriodUnit.DAY);
+        appleToGdxUnitMap.put(SKProductPeriodUnit.Week, FreeTrialPeriod.PeriodUnit.WEEK);
+        appleToGdxUnitMap.put(SKProductPeriodUnit.Month, FreeTrialPeriod.PeriodUnit.MONTH);
+        appleToGdxUnitMap.put(SKProductPeriodUnit.Year, FreeTrialPeriod.PeriodUnit.YEAR);
+    }
+
+    public static FreeTrialPeriod.PeriodUnit convertToPeriodUnit(SKProductPeriodUnit unit) {
+        return appleToGdxUnitMap.get(unit);
+    }
+
+}

--- a/gdx-pay/src/main/java/com/badlogic/gdx/pay/FreeTrialPeriod.java
+++ b/gdx-pay/src/main/java/com/badlogic/gdx/pay/FreeTrialPeriod.java
@@ -1,0 +1,70 @@
+package com.badlogic.gdx.pay;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Free trial support for subscriptions.
+ *
+ * <p>Subscriptions in App Store and Google Play can have a free trial period before starting the billing for the subscription.</p>
+ */
+public final class FreeTrialPeriod {
+
+    private final int numberOfUnits;
+
+    @Nonnull
+    private final PeriodUnit unit;
+
+    public enum PeriodUnit {
+        DAY,
+        MONTH,
+        WEEK,
+        YEAR;
+
+        public static PeriodUnit parse(char character) {
+            switch(character) {
+                case 'D':
+                    return DAY;
+                case 'W':
+                    return WEEK;
+                case 'M':
+                    return MONTH;
+                case 'Y':
+                    return YEAR;
+                default:
+                    throw new IllegalArgumentException("Character not mapped to PeriodUnit: " + character);
+            }
+        }
+    }
+
+    public FreeTrialPeriod(int numberOfUnits, PeriodUnit unit) {
+        this.numberOfUnits = numberOfUnits;
+        this.unit = unit;
+    }
+
+    public int getNumberOfUnits() {
+        return numberOfUnits;
+    }
+
+    @Nonnull
+    public PeriodUnit getUnit() {
+        return unit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FreeTrialPeriod that = (FreeTrialPeriod) o;
+
+        if (numberOfUnits != that.numberOfUnits) return false;
+        return unit == that.unit;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = numberOfUnits;
+        result = 31 * result + unit.hashCode();
+        return result;
+    }
+}

--- a/gdx-pay/src/main/java/com/badlogic/gdx/pay/Information.java
+++ b/gdx-pay/src/main/java/com/badlogic/gdx/pay/Information.java
@@ -16,9 +16,9 @@ public final class Information {
      */
     public static final Information UNAVAILABLE = new Information(null, null, null);
 
-    private String localName;
-    private String localDescription;
-    private String localPricing;
+    private final String localName;
+    private final String localDescription;
+    private final String localPricing;
 
     /**
      * @deprecated Not all currencies use cents. Currencies with no or more than 2 fractional
@@ -29,6 +29,9 @@ public final class Information {
     private Double priceAsDouble;
 
     private String priceCurrencyCode;
+
+    @Nullable
+    private FreeTrialPeriod freeTrialPeriod;
 
     public Information(String localName, String localDescription, String localPricing) {
         this.localName = localName;
@@ -43,6 +46,7 @@ public final class Information {
         priceInCents = builder.priceInCents;
         priceAsDouble = builder.priceAsDouble;
         priceCurrencyCode = builder.priceCurrencyCode;
+        freeTrialPeriod = builder.freeTrialPeriod;
     }
 
     public static Builder newBuilder() {
@@ -60,6 +64,15 @@ public final class Information {
     @Nullable
     public Integer getPriceInCents() {
         return priceInCents;
+    }
+
+    /**
+     *
+     * @return null if there is no free trial or the implementation does not support free trials.
+     */
+    @Nullable
+    public FreeTrialPeriod getFreeTrialPeriod() {
+        return freeTrialPeriod;
     }
 
     /**
@@ -157,6 +170,7 @@ public final class Information {
         private Integer priceInCents;
         private Double priceAsDouble;
         private String priceCurrencyCode;
+        private FreeTrialPeriod freeTrialPeriod;
 
         private Builder() {
         }
@@ -168,6 +182,11 @@ public final class Information {
 
         public Builder localDescription(String val) {
             localDescription = val;
+            return this;
+        }
+
+        public Builder freeTrialPeriod(FreeTrialPeriod val) {
+            freeTrialPeriod = val;
             return this;
         }
 


### PR DESCRIPTION
Subscriptions support free trial period before starting to charge for the subscription.

This PR adds the free trial period information for Google Play Billing and App Store Robovm implementation.

Verified the implementation with our own app (which has a free trial period of 3 days).

Not looked at any other implementations (such as Amazon or Huawei) as I'm not using them and thus are not able to test them. Those implementation will not expose the Free trial information even when there is actually one configured in one of those stores.

Can you have a look?