### PR TITLE
Add setObfuscatedAccountId and setObfuscatedProfileId to PurchaseManagerGoogleBilling

### DIFF
--- a/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
+++ b/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
@@ -29,16 +29,7 @@ public class PurchaseManagerGoogleBilling implements PurchaseManager, PurchasesU
     private PurchaseObserver observer;
     private PurchaseManagerConfig config;
 
-    /**
-     * Set this field to help detect fraud before it happens.
-     * See https://developer.android.com/google/play/billing/security#fraud
-     */
     private String obfuscatedAccountId;
-
-    /**
-     * Set this field to help detect fraud before it happens.
-     * See https://developer.android.com/google/play/billing/security#fraud
-     */
     private String obfuscatedProfileId;
 
     public PurchaseManagerGoogleBilling(Activity activity) {
@@ -82,10 +73,18 @@ public class PurchaseManagerGoogleBilling implements PurchaseManager, PurchasesU
         });
     }
 
+    /**
+     * Sets the obfuscated account ID to help detect fraud before it happens.
+     * See https://developer.android.com/google/play/billing/security#fraud
+     */
     public void setObfuscatedAccountId(String obfuscatedAccountId) {
         this.obfuscatedAccountId = obfuscatedAccountId;
     }
 
+    /**
+     * Sets the obfuscated profile ID to help detect fraud before it happens.
+     * See https://developer.android.com/google/play/billing/security#fraud
+     */
     public void setObfuscatedProfileId(String obfuscatedProfileId) {
         this.obfuscatedProfileId = obfuscatedProfileId;
     }

--- a/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
+++ b/gdx-pay-android-googlebilling/src/com/badlogic/gdx/pay/android/googlebilling/PurchaseManagerGoogleBilling.java
@@ -230,18 +230,16 @@ public class PurchaseManagerGoogleBilling implements PurchaseManager, PurchasesU
         if (skuDetails == null) {
             observer.handlePurchaseError(new InvalidItemException(identifier));
         } else {
-            mBillingClient.launchBillingFlow(activity, getBillingFlowParams(skuDetails));
+            mBillingClient.launchBillingFlow(activity, getBillingFlowParams(skuDetails).build());
         }
     }
 
     /**
      * @param skuDetails SKU details to set in the billing flow params.
-     * @return The params to be used while launching the billing flow.
+     * @return The params builder to be used while launching the billing flow.
      */
-    protected BillingFlowParams getBillingFlowParams(SkuDetails skuDetails) {
-        return BillingFlowParams.newBuilder()
-            .setSkuDetails(skuDetails)
-            .build();
+    protected BillingFlowParams.Builder getBillingFlowParams(SkuDetails skuDetails) {
+        return BillingFlowParams.newBuilder().setSkuDetails(skuDetails);
     }
 
     @Override


### PR DESCRIPTION
As seen in [Google documentation](https://developer.android.com/google/play/billing/security#fraud) and discussed at https://github.com/libgdx/gdx-pay/issues/228.

Let me know if you want me to add unit tests (I would be happy to). To do so, I would have to either create a fake class for `BillingClient` or use Mockito to mock it. For both strategies, I would create a protected constructor to pass `mBillingClient` as argument.

Thanks! 