### PR TITLE
#230 use logic available in iOS 11.2 and up only if available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ task wrapper(type: Wrapper) {
 
 allprojects {
     group = 'com.badlogicgames.gdxpay'
-    version = '1.3.0'
+    version = '1.4.0-SNAPSHOT'
 }
 
 class Developer {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ task wrapper(type: Wrapper) {
 
 allprojects {
     group = 'com.badlogicgames.gdxpay'
-    version = '1.4.0-SNAPSHOT'
+    version = '1.3.1-SNAPSHOT'
 }
 
 class Developer {

--- a/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/IosVersion.java
+++ b/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/IosVersion.java
@@ -1,0 +1,16 @@
+package com.badlogic.gdx.pay.ios.apple;
+
+import org.robovm.apple.foundation.Foundation;
+
+enum IosVersion {
+    ;
+
+    static boolean isIos_7_0_orAbove() {
+        return Foundation.getMajorSystemVersion() >= 7;
+    }
+
+    static boolean is_11_2_OrAbove() {
+        return ((Foundation.getMajorSystemVersion()  == 11 && Foundation.getMinorSystemVersion() >= 2)
+                || Foundation.getMajorSystemVersion() > 11);
+    }
+}

--- a/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
+++ b/gdx-pay-iosrobovm-apple/src/main/java/com/badlogic/gdx/pay/ios/apple/PurchaseManageriOSApple.java
@@ -227,7 +227,7 @@ public class PurchaseManageriOSApple implements PurchaseManager {
 
         if (payment.getRequestData() != null) {
             final String transactionData;
-            if (Foundation.getMajorSystemVersion() >= 7) {
+            if (IosVersion.isIos_7_0_orAbove()) {
                 transactionData = payment.getRequestData().toBase64EncodedString(NSDataBase64EncodingOptions.None);
             } else {
                 transactionData = Base64.encode(payment.getRequestData().getBytes());
@@ -543,6 +543,11 @@ public class PurchaseManageriOSApple implements PurchaseManager {
     }
 
     private FreeTrialPeriod convertToFreeTrialPeriod(SKProduct product) {
+        if (!IosVersion.is_11_2_OrAbove()) {
+            // introductoryPrice is introduced in ios 11.2
+            return null;
+        }
+
         final SKProductDiscount introductoryPrice = product.getIntroductoryPrice();
         if (introductoryPrice == null || introductoryPrice.getSubscriptionPeriod() == null || introductoryPrice.getSubscriptionPeriod().getNumberOfUnits() == 0) {
             return null;


### PR DESCRIPTION
Apps with iOS < 11.2 and subscriptions crashed, some methods only available on 11.2 and higher where used.

This has been solved.