### PR TITLE
Removed login dialog when installing InApps for Huawei

### DIFF
--- a/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
+++ b/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
@@ -54,7 +54,6 @@ public class HuaweiPurchaseManager implements PurchaseManager, AndroidEventListe
     private final String TAG = "HuaweiPurchaseManager";
 
     private final int PURCHASE_STATUS_RESULT_CODE = 7265;
-    private final int NOT_LOGGED_IN_STATUS_RESULT_CODE = 7264;
 
     private final AndroidApplication activity;
     private final HuaweiPurchaseManagerConfig huaweiPurchaseManagerConfig = new HuaweiPurchaseManagerConfig();
@@ -79,18 +78,8 @@ public class HuaweiPurchaseManager implements PurchaseManager, AndroidEventListe
                     IapApiException apiException = (IapApiException) e;
                     Status status = apiException.getStatus();
                     if (status.getStatusCode() == OrderStatusCode.ORDER_HWID_NOT_LOGIN) {
-                        // Not logged in.
-                        if (status.hasResolution()) {
-                            try {
-                                status.startResolutionForResult(activity, NOT_LOGGED_IN_STATUS_RESULT_CODE);
-                            } catch (IntentSender.SendIntentException ex) {
-                                huaweiPurchaseManagerConfig.observer.handleInstallError(ex);
-                            }
-                        } else {
                             huaweiPurchaseManagerConfig.observer.handleInstallError(new LoginRequiredException());
-                        }
                     } else if (status.getStatusCode() == OrderStatusCode.ORDER_ACCOUNT_AREA_NOT_SUPPORTED) {
-                        // The current region does not support HUAWEI IAP.
                         huaweiPurchaseManagerConfig.observer.handleInstallError(new RegionNotSupportedException());
                     } else {
                         huaweiPurchaseManagerConfig.observer.handleInstallError(e);


### PR DESCRIPTION
Removed login dialog when installing InApps for Huawei. Changed to call handleInstallError when user is not logged in.
There was a problem when installing InApps when user is logged out. HuaweiPurchaseManager was opening login window - handleInstallError was not called and InApp products was still not installed after successful login. I think that it will be better to call handleInstallError and leave it to a programmer - he can open login window or show text dialog.