### PR TITLE
Documentation - Replace deprecated gradle compile with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Add the following dependencies:
 
 *core:*
 
-        compile "com.badlogicgames.gdxpay:gdx-pay-client:$gdxPayVersion"
+        implementation "com.badlogicgames.gdxpay:gdx-pay-client:$gdxPayVersion"
 
 *html:*
 
-        compile "com.badlogicgames.gdxpay:gdx-pay:$gdxPayVersion:sources"
-        compile "com.badlogicgames.gdxpay:gdx-pay-client:$gdxPayVersion:sources"
+        implementation "com.badlogicgames.gdxpay:gdx-pay:$gdxPayVersion:sources"
+        implementation "com.badlogicgames.gdxpay:gdx-pay-client:$gdxPayVersion:sources"
 
 You also need to add the following file to your GdxDefinition.gwt.xml in your html project:
 

--- a/gdx-pay-android-amazon/README.md
+++ b/gdx-pay-android-amazon/README.md
@@ -8,7 +8,7 @@ Handles purchases and restores for non-consumable and consumable products, will 
 
  *android:*
 
-     compile "com.badlogicgames.gdxpay:gdx-pay-android-amazon:$gdxPayVersion"
+     implementation "com.badlogicgames.gdxpay:gdx-pay-android-amazon:$gdxPayVersion"
 
 
 ### ProGuard configuration

--- a/gdx-pay-android-googlebilling/README.md
+++ b/gdx-pay-android-googlebilling/README.md
@@ -10,7 +10,7 @@ Subscriptions are supported with some limitations: the first `SubscriptionOfferD
 
 *android:*
 
-     compile "com.badlogicgames.gdxpay:gdx-pay-android-googlebilling:$gdxPayVersion"
+     implementation "com.badlogicgames.gdxpay:gdx-pay-android-googlebilling:$gdxPayVersion"
 
 
 ### ProGuard configuration

--- a/gdx-pay-android-huawei/README.md
+++ b/gdx-pay-android-huawei/README.md
@@ -8,7 +8,7 @@ It manages purchases, restores and consumption for consumable, non-consumable an
 
  *android:*
 
-     compile "com.badlogicgames.gdxpay:gdx-pay-android-huawei:$gdxPayVersion"
+     implementation "com.badlogicgames.gdxpay:gdx-pay-android-huawei:$gdxPayVersion"
 
 
 ### ProGuard configuration

--- a/gdx-pay-iosrobovm-apple/README.md
+++ b/gdx-pay-iosrobovm-apple/README.md
@@ -2,7 +2,7 @@
 
 ### Dependencies
 
-     compile "com.badlogicgames.gdxpay:gdx-pay-iosrobovm-apple:$gdxPayVersion"
+     implementation "com.badlogicgames.gdxpay:gdx-pay-iosrobovm-apple:$gdxPayVersion"
 
 ### Instantiation
 


### PR DESCRIPTION
The `compile` configuration in Gradle has been deprecated and replaced by the `implementation` configuration.
Source: https://gradlehero.com/gradle-implementation-vs-compile-dependencies/