### PR TITLE
Fixed bug - no handleInstallError() was fired when Huawei Environment was not ready

### DIFF
--- a/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
+++ b/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
@@ -74,17 +74,17 @@ public class HuaweiPurchaseManager implements PurchaseManager, AndroidEventListe
         }).addOnFailureListener(new OnFailureListener() {
             @Override
             public void onFailure(Exception e) {
-                Exception installErrorException = e;
                 if (e instanceof IapApiException) {
                     IapApiException apiException = (IapApiException) e;
                     Status status = apiException.getStatus();
                     if (status.getStatusCode() == OrderStatusCode.ORDER_HWID_NOT_LOGIN) {
-                        installErrorException = new LoginRequiredException();
+                            huaweiPurchaseManagerConfig.observer.handleInstallError(new LoginRequiredException());
                     } else if (status.getStatusCode() == OrderStatusCode.ORDER_ACCOUNT_AREA_NOT_SUPPORTED) {
-                        installErrorException = new RegionNotSupportedException();
+                        huaweiPurchaseManagerConfig.observer.handleInstallError(new RegionNotSupportedException());
+                    } else {
+                        huaweiPurchaseManagerConfig.observer.handleInstallError(e);
                     }
                 }
-                huaweiPurchaseManagerConfig.observer.handleInstallError(installErrorException);
             }
         });
     }

--- a/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
+++ b/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
@@ -74,17 +74,17 @@ public class HuaweiPurchaseManager implements PurchaseManager, AndroidEventListe
         }).addOnFailureListener(new OnFailureListener() {
             @Override
             public void onFailure(Exception e) {
+                Exception installErrorException = e;
                 if (e instanceof IapApiException) {
                     IapApiException apiException = (IapApiException) e;
                     Status status = apiException.getStatus();
                     if (status.getStatusCode() == OrderStatusCode.ORDER_HWID_NOT_LOGIN) {
-                            huaweiPurchaseManagerConfig.observer.handleInstallError(new LoginRequiredException());
+                        installErrorException = new LoginRequiredException();
                     } else if (status.getStatusCode() == OrderStatusCode.ORDER_ACCOUNT_AREA_NOT_SUPPORTED) {
-                        huaweiPurchaseManagerConfig.observer.handleInstallError(new RegionNotSupportedException());
-                    } else {
-                        huaweiPurchaseManagerConfig.observer.handleInstallError(e);
+                        installErrorException = new RegionNotSupportedException();
                     }
                 }
+                huaweiPurchaseManagerConfig.observer.handleInstallError(installErrorException);
             }
         });
     }

--- a/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
+++ b/gdx-pay-android-huawei/src/main/java/com/badlogic/gdx/pay/android/huawei/HuaweiPurchaseManager.java
@@ -84,6 +84,8 @@ public class HuaweiPurchaseManager implements PurchaseManager, AndroidEventListe
                     } else {
                         huaweiPurchaseManagerConfig.observer.handleInstallError(e);
                     }
+                } else {
+                    huaweiPurchaseManagerConfig.observer.handleInstallError(e);
                 }
             }
         });


### PR DESCRIPTION
There was a problem when `onFailure()` was fired with Exception other than `IapApiException`. No observer methods was fired (`handleInstall()` or `handleInstallError()`), so it was unknown that IAP was not installed. I had this problem when installing on fresh device without HMS Core installed. `handleInstall()` or `handleInstallError()` was not fired when user canceled HMS Core installation because throwned Exception was not instance of `IapApiException`