### PR TITLE
Update AndroidManifest.xml according to the Amazon

### DIFF
--- a/gdx-pay-android-amazon/AndroidManifest.xml
+++ b/gdx-pay-android-amazon/AndroidManifest.xml
@@ -5,14 +5,11 @@
     <application>
 
         <!-- IAP -->
-        <receiver
-                android:name="com.amazon.device.iap.ResponseReceiver"
-                tools:ignore="ExportedReceiver,InvalidPermission" android:exported="false">
+        <receiver android:name="com.amazon.device.iap.ResponseReceiver" android:exported="true"
+            android:permission="com.amazon.inapp.purchasing.Permission.NOTIFY" >
             <intent-filter>
                 <action
-                    android:name="com.amazon.inapp.purchasing.NOTIFY"
-                    android:permission="com.amazon.inapp.purchasing.Permission.NOTIFY"
-                    />
+                    android:name="com.amazon.inapp.purchasing.NOTIFY" />
             </intent-filter>
         </receiver>
 


### PR DESCRIPTION
document link:
https://developer.amazon.com/docs/in-app-purchasing/iap-implement-iap.html

Current version doesn't call handlePurchase or handlePurchaseError after purchasing, when target Android API 33.
After this update of ResponseReceiver configuration, everything goes normal.