### PR TITLE
Upgrade to Google Billing to version 6.0.0

### DIFF
--- a/gdx-pay-android-googlebilling/build.gradle
+++ b/gdx-pay-android-googlebilling/build.gradle
@@ -37,7 +37,7 @@ configurations {
 
 dependencies {
     api project(':gdx-pay-client')
-    api 'com.android.billingclient:billing:5.0.0'
+    api "com.android.billingclient:billing:6.0.0"
 
     testImplementation libraries.junit
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.badlogicgames.gdxpay
-version=1.3.6
+version=1.3.6-SNAPSHOT
 POM_DESCRIPTION=Gdx Payment library
 POM_NAME=libGDX Payment API
 POM_URL=https://github.com/libgdx/gdx-pay
@@ -10,3 +10,4 @@ POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 org.gradle.jvmargs=-Xms1024m -Xmx2048m
+android.useAndroidX=true


### PR DESCRIPTION
Upgraded billing library to 6.0.0

Please also read https://developer.android.com/google/play/billing/migrate-gpblv6, changes in Google Play console must be checked as you might have to reconfigure your subscriptions.

Android 14 needs the latest version of gdx-pay (1.3.6)

Any reviews by other maintainers are welcome, otherwise I'll release it in 12 hours from now