### PR TITLE
Update gdx-pay-android-googlebilling to minSdk 21

### DIFF
--- a/gdx-pay-android-googlebilling/build.gradle
+++ b/gdx-pay-android-googlebilling/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion androidTargetSdkVersion
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
         testOptions {


### PR DESCRIPTION
I don't follow this repository but I saw #274. We can update the minSdk since Google Play Billing itself requires it as per https://play.google.com/sdks/details/com-android-billingclient-billing. libGDX itself is on 21 now.

Separately, I'd recommend a developer reviews this to see if target can be bumped to 36:  
https://github.com/libgdx/gdx-pay/blob/bf4d166f89e252169269b00e242d0b39761df613/build.gradle#L13-L15