### PR TITLE
Allow subscriptions and in-app products to be registered at the same time.

### DIFF
--- a/gdx-pay-android-googlebilling/build.gradle
+++ b/gdx-pay-android-googlebilling/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 24
         targetSdkVersion androidTargetSdkVersion
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
         testOptions {


### PR DESCRIPTION
When you try to register both in-app purchases and subscriptions at the same time, you get this following error: 

IllegalArgumentException: All products should be of the same product type. at QueryProductDetailsParams$Builder.setProductList at com.badlogic.gdx.pay.android.googlebilling.PurchaseManagerGoogleBilling.fetchOfferDetails(...)

This change separates the registration, and everything should be working the same as before.